### PR TITLE
Add conditional rendering to rocket reserve button

### DIFF
--- a/src/assets/scss/modules/_rocket.scss
+++ b/src/assets/scss/modules/_rocket.scss
@@ -28,12 +28,33 @@
 
     color: $typoColor;
     font-size: 1.1rem;
+    line-height: 1.5rem;
+    height: 4rem;
+
+    &__reserved {
+      background-color: $secondaryColor;
+      color: #fff;
+      border-radius: 3px;
+      padding: 0.2rem;
+      margin-right: 0.5rem;
+      font-size: 0.8rem;
+    }
   }
 
-  &__button {
+  &__cancelbutton {
+    color: $web-gray;
+    background-color: #fff;
+    border: 1px solid $typoColor;
+    padding: 0.5rem;
+    border-radius: 3px;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+
+  &__reservebutton {
     color: #fff;
     background-color: $primaryColor;
-    border: none;
+    border: 1px solid $primaryColor;
     padding: 0.5rem;
     border-radius: 3px;
     font-size: 1rem;

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -6,7 +6,7 @@ const Rocket = (props) => {
   const dispatch = useDispatch();
 
   const {
-    name, description, image, id,
+    name, description, image, id, reserved,
   } = props;
 
   return (
@@ -14,8 +14,14 @@ const Rocket = (props) => {
       <img className="rocket-container__img" src={image} alt={name} />
       <div className="rocket-info">
         <h2 className="rocket-info__title">{name}</h2>
-        <p className="rocket-info__description">{description}</p>
-        <button className="rocket-info__button" type="button" onClick={() => dispatch(updateRocket(id))}>Test</button>
+        <p className="rocket-info__description">
+          {reserved
+            && <span className="rocket-info__description__reserved">Reserved</span>}
+          {description}
+        </p>
+        {reserved
+          ? <button className="rocket-info__cancelbutton" type="button" onClick={() => dispatch(updateRocket(id))}>Cancel Reservation</button>
+          : <button className="rocket-info__reservebutton" type="button" onClick={() => dispatch(updateRocket(id))}>Reserve Rocket</button>}
       </div>
     </li>
   );
@@ -26,6 +32,7 @@ Rocket.propTypes = {
   description: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired,
+  reserved: PropTypes.bool.isRequired,
 };
 
 export default Rocket;


### PR DESCRIPTION
- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design).
- Conditional rendering is applied using the logical && operator and Ternary operator.